### PR TITLE
fix (timeline): remove outdated nodes from EventTimeline

### DIFF
--- a/src/Sportradar.OddsFeed.SDK/Entities/REST/Internal/Caching/CI/EventTimelineCI.cs
+++ b/src/Sportradar.OddsFeed.SDK/Entities/REST/Internal/Caching/CI/EventTimelineCI.cs
@@ -83,6 +83,7 @@ namespace Sportradar.OddsFeed.SDK.Entities.REST.Internal.Caching.CI
                 }
                 else
                 {
+                    // add/update
                     foreach (var basicEvent in dto.BasicEvents)
                     {
                         var timelineEvent = _timeline.FirstOrDefault(s => s.Id == basicEvent.Id);
@@ -95,6 +96,9 @@ namespace Sportradar.OddsFeed.SDK.Entities.REST.Internal.Caching.CI
                             _timeline.Add(new TimelineEventCI(basicEvent, culture));
                         }
                     }
+
+                    // delete
+                    _timeline.RemoveAll(timelineEvent => dto.BasicEvents.All(basicEvent => basicEvent.Id != timelineEvent.Id));
                 }
             }
 

--- a/src/Sportradar.OddsFeed.SDK/Sportradar.OddsFeed.SDK.xml
+++ b/src/Sportradar.OddsFeed.SDK/Sportradar.OddsFeed.SDK.xml
@@ -12922,6 +12922,11 @@
             The qualifying part
             </summary>
         </member>
+        <member name="F:Sportradar.OddsFeed.SDK.Entities.REST.Enums.StageType.Lap">
+            <summary>
+            The lap
+            </summary>
+        </member>
         <member name="T:Sportradar.OddsFeed.SDK.Entities.REST.Enums.TimeType">
             <summary>
             Enumeration of possible time types

--- a/src/Tests/Sportradar.OddsFeed.SDK.Entities.REST.Test/FixtureInternalMapperTest.cs
+++ b/src/Tests/Sportradar.OddsFeed.SDK.Entities.REST.Test/FixtureInternalMapperTest.cs
@@ -52,7 +52,7 @@ namespace Sportradar.OddsFeed.SDK.Entities.REST.Test
             _assertHelper.AreEqual(() => _entity.Scheduled, _record.fixture.scheduledSpecified ? (DateTime?)_record.fixture.scheduled : null);
             _assertHelper.AreEqual(() => _entity.StartTime, _record.fixture.start_time);
             _assertHelper.AreEqual(() => _entity.NextLiveTime, SdkInfo.ParseDate(_record.fixture.next_live_time));
-            _assertHelper.AreEqual(() => _entity.StartTimeTBD, _record.fixture.start_time_tbdSpecified ? (bool?) _record.fixture.start_time_tbd : null);
+            _assertHelper.AreEqual(() => _entity.StartTimeTbd, _record.fixture.start_time_tbdSpecified ? (bool?) _record.fixture.start_time_tbd : null);
             _assertHelper.AreEqual(() => _entity.StartTimeConfirmed, _record.fixture.start_time_confirmed);
 
             _assertHelper.AreEqual(() => _entity.Season.Id.ToString(), _record.fixture.season.id);

--- a/src/Tests/Sportradar.OddsFeed.SDK.Entities.REST.Test/RestMessageMappingTest.cs
+++ b/src/Tests/Sportradar.OddsFeed.SDK.Entities.REST.Test/RestMessageMappingTest.cs
@@ -112,14 +112,14 @@ namespace Sportradar.OddsFeed.SDK.Entities.REST.Test
             Assert.AreEqual(msg.scheduled, dto.Scheduled);
             Assert.AreEqual(msg.scheduled_end, dto.ScheduledEnd);
             Assert.AreEqual(!string.IsNullOrEmpty(msg.replaced_by) ? URN.Parse(msg.replaced_by) : null, dto.ReplacedBy);
-            Assert.AreEqual(msg.start_time_tbdSpecified ? (bool?)msg.start_time_tbd : null, dto.StartTimeTBD);
+            Assert.AreEqual(msg.start_time_tbdSpecified ? (bool?)msg.start_time_tbd : null, dto.StartTimeTbd);
             Assert.AreEqual(msg.competitors.Length, dto.Competitors.Count());
 
             for (var i = 0; i < msg.competitors.Length; i++)
             {
                 ValidateTeamCompetitor(msg.competitors[i], dto.Competitors.ToList()[i]);
             }
-            ValidateCoverageInfo(msg.coverage_info, dto.CoverageInfo);
+            ValidateCoverageInfo(msg.coverage_info, dto.Coverage);
             Assert.AreEqual(msg.delayed_info.id, dto.DelayedInfo.Id);
 
             Assert.AreEqual(msg.extra_info.Length, dto.ExtraInfo.ToList().Count);


### PR DESCRIPTION
For instance, on a soccer match, during VAR, if a goal is cancelled, 'score_change' node disappear from timeline xml but is still present into EventTimeline in cache after merge operation