### PR TITLE
Thread deadlocking in Competitor profile due to Task.Run().Wait()

### DIFF
--- a/src/Sportradar.OddsFeed.SDK.Tests.Common/TestCompetitor.cs
+++ b/src/Sportradar.OddsFeed.SDK.Tests.Common/TestCompetitor.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Threading.Tasks;
 using Sportradar.OddsFeed.SDK.Entities.REST;
 using Sportradar.OddsFeed.SDK.Messages;
 
@@ -147,5 +148,10 @@ namespace Sportradar.OddsFeed.SDK.Tests.Common
         /// </summary>
         /// <value>The state</value>
         public string State { get; }
+
+        public Task EnsureProfileLoaded()
+        {
+            return Task.CompletedTask;
+        }
     }
 }

--- a/src/Sportradar.OddsFeed.SDK/Entities/REST/ICompetitor.cs
+++ b/src/Sportradar.OddsFeed.SDK/Entities/REST/ICompetitor.cs
@@ -122,5 +122,11 @@ namespace Sportradar.OddsFeed.SDK.Entities.REST
         /// </summary>
         /// <value>The short name</value>
         string ShortName => null;
+
+        /// <summary>
+        /// Ensures the profile is loaded for the competitor. This makes use of async await to avoid Task.Run().Wait() deadlocks
+        /// </summary>
+        /// <returns></returns>
+        Task EnsureProfileLoaded();
     }
 }

--- a/src/Sportradar.OddsFeed.SDK/Entities/REST/Internal/EntitiesImpl/Competitor.cs
+++ b/src/Sportradar.OddsFeed.SDK/Entities/REST/Internal/EntitiesImpl/Competitor.cs
@@ -266,6 +266,12 @@ namespace Sportradar.OddsFeed.SDK.Entities.REST.Internal.EntitiesImpl
         /// <value>The short name</value>
         public string ShortName => GetOrLoadCompetitor()?.ShortName;
 
+        public async Task EnsureProfileLoaded()
+        {
+            // Ensure cache is loaded
+            await GetOrLoadCompetitorAsync();
+        }
+
         /// <summary>
         /// Initializes a new instance of the <see cref="Competitor"/> class
         /// </summary>
@@ -502,6 +508,23 @@ namespace Sportradar.OddsFeed.SDK.Entities.REST.Internal.EntitiesImpl
             if (_competitorCI != null && _profileCache != null && _lastCompetitorFetch < DateTime.Now.AddSeconds(-30))
             {
                 LoadCompetitorProfileInCache();
+                _lastCompetitorFetch = DateTime.Now;
+            }
+
+            return _competitorCI;
+        }
+
+        private async Task<CompetitorCI> GetOrLoadCompetitorAsync()
+        {
+            if (_competitorId != null && _competitorCI == null && _profileCache != null)
+            {
+                _competitorCI = await _profileCache.GetCompetitorProfileAsync(_competitorId, _cultures).ConfigureAwait(false);
+                _lastCompetitorFetch = DateTime.Now;
+            }
+
+            if (_competitorCI != null && _profileCache != null && _lastCompetitorFetch < DateTime.Now.AddSeconds(-30))
+            {
+                _competitorCI = await _profileCache.GetCompetitorProfileAsync(_competitorId, _cultures).ConfigureAwait(false);
                 _lastCompetitorFetch = DateTime.Now;
             }
 

--- a/src/Sportradar.OddsFeed.SDK/Entities/REST/Internal/MarketNames/EntityNameExpression.cs
+++ b/src/Sportradar.OddsFeed.SDK/Entities/REST/Internal/MarketNames/EntityNameExpression.cs
@@ -107,13 +107,21 @@ namespace Sportradar.OddsFeed.SDK.Entities.REST.Internal.MarketNames
             if (_sportEvent is IMatch match)
             {
                 var competitor = await InvokeAndWrapAsync(match.GetHomeCompetitorAsync).ConfigureAwait(false);
+                await competitor.EnsureProfileLoaded();
                 return competitor?.GetName(culture);
             }
 
             if (_sportEvent is IStage stage)
             {
                 var competitors = await InvokeAndWrapAsync(stage.GetCompetitorsAsync).ConfigureAwait(false);
-                return competitors?.First().GetName(culture);
+                var competitor = competitors?.First();
+                if (competitor != null)
+                {
+                    await competitor.EnsureProfileLoaded();
+                    return competitor.GetName(culture);
+                }
+
+                return null;
             }
 
             throw new NameExpressionException($"Operand {_propertyName} is not supported. Supported operands are: {string.Join(",", SupportedOperands)}", null);
@@ -124,13 +132,21 @@ namespace Sportradar.OddsFeed.SDK.Entities.REST.Internal.MarketNames
             if (_sportEvent is IMatch match)
             {
                 var competitor = await InvokeAndWrapAsync(match.GetAwayCompetitorAsync).ConfigureAwait(false);
+                await competitor.EnsureProfileLoaded();
                 return competitor?.GetName(culture);
             }
 
             if (_sportEvent is IStage stage)
             {
                 var competitors = await InvokeAndWrapAsync(stage.GetCompetitorsAsync).ConfigureAwait(false);
-                return competitors?.Skip(1).First().GetName(culture);
+                var competitor = competitors?.Skip(1).First();
+                if (competitor != null)
+                {
+                    await competitor.EnsureProfileLoaded();
+                    return competitor.GetName(culture);
+                }
+
+                return null;
             }
 
             throw new NameExpressionException($"Operand {_propertyName} is not supported. Supported operands are: {string.Join(",", SupportedOperands)}", null);

--- a/src/Sportradar.OddsFeed.SDK/Sportradar.OddsFeed.SDK.xml
+++ b/src/Sportradar.OddsFeed.SDK/Sportradar.OddsFeed.SDK.xml
@@ -14790,6 +14790,12 @@
             </summary>
             <value>The short name</value>
         </member>
+        <member name="M:Sportradar.OddsFeed.SDK.Entities.REST.ICompetitor.EnsureProfileLoaded">
+            <summary>
+            Ensures the profile is loaded for the competitor. This makes use of async await to avoid Task.Run().Wait() deadlocks
+            </summary>
+            <returns></returns>
+        </member>
         <member name="T:Sportradar.OddsFeed.SDK.Entities.REST.ICompetitorResult">
             <summary>
             Defines contract used by classes that provide competitor result information


### PR DESCRIPTION
Upgrading to version 1.30.x there was a noticed issue with threads locking specifically on start up of services connecting to the Betradar Feed. It was also noticed during recovery and at peak times. This has been noticed in both the integration and production environments.

This is was initially seen by looking at the threadpool queue length
![image](https://user-images.githubusercontent.com/1596315/227557031-d7f9cd89-af31-491c-85fa-fffc849a42a7.png)

Investigations were done by running dot trace and pointing to the Task.Wait in the LoadProfileInCache (Code - https://github.com/sportradar/UnifiedOddsSdkNetCore/blob/master/src/Sportradar.OddsFeed.SDK/Entities/REST/Internal/EntitiesImpl/Competitor.cs#L511)

![image](https://user-images.githubusercontent.com/1596315/227557598-f5e10f64-2641-458c-bc9a-052fb4ca33c2.png)
The dtt file can be made available if needed. 

The problem with the code is that doing `Task.Run().Wait()` will wait on the thread for the response and deadlock that thread. This problem is explained in depth in this blog post https://blog.stephencleary.com/2012/07/dont-block-on-async-code.html

The current thinking is that this issue has been around for a while but the change to increase the SemaphorePool count to 500 has contributed to this problem being more visible https://github.com/sportradar/UnifiedOddsSdkNetCore/blob/c898704f8d6d15365f335ea35db0ef2df477a325/src/Sportradar.OddsFeed.SDK/API/Internal/UnityFeedBootstrapper.cs#L275

The code in the PR has been running in our production environment for approximately two weeks and we have noticed an improvement and have no thread queuing issues.

Exposing `EnsureProfileLoaded()` on `ICompetitor` allows the users to opt into loading a profile into cache using `await` and not having to incur the thread deadlock when trying to get data from the various properties on the `ICompetitor` interface which in the implementation calls `LoadCompetitorProfileInCache` which deadlocks. This is something currently being used in production.

There is also the the potential to apply a similar approach for `FetchEventCompetitorsVirtual` which suffers from the same thread locking problem.

Please note that I originally raised this through the SportRadar support process which I have not had a technical response since it was reported. The internal ticket number is `Ticket#857483`. For any further details or any other questions specific to our integration we would be happy to get onto a call about this.