### PR TITLE
Fix: IDispatcherStore DI lifetime

### DIFF
--- a/src/Sportradar.OddsFeed.SDK/API/Internal/UnityFeedBootstrapper.cs
+++ b/src/Sportradar.OddsFeed.SDK/API/Internal/UnityFeedBootstrapper.cs
@@ -276,7 +276,7 @@ namespace Sportradar.OddsFeed.SDK.API.Internal
 
             container.RegisterType<IMessageDataExtractor, MessageDataExtractor>(new ContainerControlledLifetimeManager());
             container.RegisterType<IEntityTypeMapper, EntityTypeMapper>(new ContainerControlledLifetimeManager());
-            container.RegisterType<IDispatcherStore, DispatcherStore>(new ContainerControlledLifetimeManager());
+            container.RegisterType<IDispatcherStore, DispatcherStore>(new HierarchicalLifetimeManager());
             container.RegisterType<ISemaphorePool, SemaphorePool>(
                 new ContainerControlledLifetimeManager(),
                 new InjectionConstructor(500, config.ExceptionHandlingStrategy));


### PR DESCRIPTION
This commit addresses an issue where the IDispatcherStore was being shared between multiple IOddsFeedSession instances.

Currently, we utilize separate IOddsFeedSession objects for handling MessageInterest.LiveMessagesOnly and MessageInterest.PrematchMessagesOnly scenarios.

The code snippet below illustrates the session creation process:

```csharp
_logger.LogInformation("Creating IOddsFeedSessions");
_oddsFeedPrematchSession = _oddsFeed.CreateBuilder()
    .SetMessageInterest(MessageInterest.PrematchMessagesOnly)
    .Build();
_oddsFeedLiveSession = _oddsFeed.CreateBuilder()
    .SetMessageInterest(MessageInterest.LiveMessagesOnly)
    .Build();

_logger.LogInformation("Creating entity specific dispatchers");
_prematchMatchDispatcher = _oddsFeedPrematchSession.CreateSportSpecificMessageDispatcher<IMatch>();
_prematchStageDispatcher = _oddsFeedPrematchSession.CreateSportSpecificMessageDispatcher<IStage>();
_prematchTournamentDispatcher = _oddsFeedPrematchSession.CreateSportSpecificMessageDispatcher<ITournament>();
_prematchBasicTournamentDispatcher = _oddsFeedPrematchSession.CreateSportSpecificMessageDispatcher<IBasicTournament>();
_prematchSeasonDispatcher = _oddsFeedPrematchSession.CreateSportSpecificMessageDispatcher<ISeason>();

_liveMatchDispatcher = _oddsFeedLiveSession.CreateSportSpecificMessageDispatcher<IMatch>();
```

Upon closer examination, it was discovered that the _oddsFeedLiveSession object was inadvertently sharing the same set of dispatchers as the _oddsFeedPrematchSession. Consequently, attempting to create a dispatcher for the _oddsFeedLiveSession led to an exception.

To resolve this issue, the proposed changes ensure that each session (_oddsFeedPrematchSession and _oddsFeedLiveSession) has its own set of distinct dispatchers, eliminating the exception and providing the expected behavior.